### PR TITLE
fix: Enforce candidate-only editing and improve sync

### DIFF
--- a/convex/interviews.ts
+++ b/convex/interviews.ts
@@ -21,7 +21,12 @@ export const updateInterviewQuestion = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthorized");
 
-    // TODO: Add more granular authorization if needed (e.g., only interviewer can change question)
+    const interview = await ctx.db.get(args.interviewId);
+    if (!interview) throw new Error("Interview not found");
+
+    if (identity.subject !== interview.candidateId) {
+      throw new Error("User is not authorized to make changes to this interview's question.");
+    }
 
     return await ctx.db.patch(args.interviewId, {
       selectedQuestionId: args.questionId,
@@ -95,13 +100,12 @@ export const updateInterviewCode = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthorized");
 
-    // TODO: Add more granular authorization if needed
-    // For now, any authenticated user can update.
-    // const interview = await ctx.db.get(args.interviewId);
-    // if (!interview) throw new Error("Interview not found");
-    // if (interview.candidateId !== identity.subject && !interview.interviewerIds.includes(identity.subject)) {
-    //   throw new Error("User not authorized to update this interview");
-    // }
+    const interview = await ctx.db.get(args.interviewId);
+    if (!interview) throw new Error("Interview not found");
+
+    if (identity.subject !== interview.candidateId) {
+      throw new Error("User is not authorized to make changes to this interview's code.");
+    }
 
     return await ctx.db.patch(args.interviewId, {
       currentCode: args.code,
@@ -118,8 +122,12 @@ export const updateInterviewLanguage = mutation({
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Unauthorized");
 
-    // TODO: Add more granular authorization if needed
-    // For now, any authenticated user can update.
+    const interview = await ctx.db.get(args.interviewId);
+    if (!interview) throw new Error("Interview not found");
+
+    if (identity.subject !== interview.candidateId) {
+      throw new Error("User is not authorized to make changes to this interview's language.");
+    }
 
     return await ctx.db.patch(args.interviewId, {
       currentLanguage: args.language,


### PR DESCRIPTION
This commit addresses feedback on the real-time interview features:

1.  **Candidate-Only Editing:**
    - Modified `updateInterviewCode`, `updateInterviewLanguage`, and `updateInterviewQuestion` mutations in `convex/interviews.ts` to only allow the `candidateId` associated with the interview to make changes.
    - Updated `CodeEditor.tsx` to make the Monaco editor `readOnly` and disable language/question selection dropdowns if you are not the candidate.

2.  **Improved Language and Code Synchronization:**
    - Refined `CodeEditor.tsx` event handlers and effects to ensure that when the language or question is changed (either locally by the candidate or via remote updates), the code editor's content (especially starter code) is consistently updated and synchronized for all participants.
    - Specifically, when the candidate changes language, the new language and the corresponding starter code are now both saved to the backend.

These changes ensure a more robust and permission-aware collaborative coding experience. The language selection is now reliably saved and synchronized, and editing capabilities are correctly restricted to the candidate.